### PR TITLE
Prefilled jetconfigs for templates DEV-837

### DIFF
--- a/api/jetconfig.yaml
+++ b/api/jetconfig.yaml
@@ -6,10 +6,6 @@ environment:
     flags:
       min-replicas: 1
       public: true
-  preview:
-    flags:
-      min-replicas: 1
-      public: true
   prod:
     flags:
       min-replicas: 1

--- a/api/jetconfig.yaml
+++ b/api/jetconfig.yaml
@@ -1,0 +1,16 @@
+configVersion: "1.0"
+application:
+  name: api
+environment:
+  dev:
+    flags:
+      min-replicas: 1
+      public: true
+  preview:
+    flags:
+      min-replicas: 1
+      public: true
+  prod:
+    flags:
+      min-replicas: 1
+      public: true

--- a/background_job/jetconfig.yaml
+++ b/background_job/jetconfig.yaml
@@ -6,10 +6,6 @@ environment:
     flags:
       min-replicas: 1
       public: true
-  preview:
-    flags:
-      min-replicas: 1
-      public: true
   prod:
     flags:
       min-replicas: 1

--- a/background_job/jetconfig.yaml
+++ b/background_job/jetconfig.yaml
@@ -1,0 +1,16 @@
+configVersion: "1.0"
+application:
+  name: background-job
+environment:
+  dev:
+    flags:
+      min-replicas: 1
+      public: true
+  preview:
+    flags:
+      min-replicas: 1
+      public: true
+  prod:
+    flags:
+      min-replicas: 1
+      public: true

--- a/cronjob/jetconfig.yaml
+++ b/cronjob/jetconfig.yaml
@@ -1,0 +1,3 @@
+configVersion: "1.0"
+application:
+  name: cronjob


### PR DESCRIPTION
Added `jetconfig.yaml` file to templates so that jetpack create doesn't invoke questions.

@Lagoja @LucilleH I'm not sure if the jetconfig files for these templates have the correct values. Feel free to suggest changes.